### PR TITLE
Update translations

### DIFF
--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -31,7 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
-        vol.Required(CONF_PORT): cv.positive_int,
+        vol.Required(CONF_PORT, default=7700): cv.positive_int,
         vol.Required(CONF_PASSWORD): str,
     }
 )

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -13,7 +13,7 @@
                 "data": {
                     "host": "Host",
                     "port": "Port",
-                    "password": "Automation Passcode"
+                    "password": "Solutions Series: RSC+ Passcode\nOther Panels: Automation Passcode"
                 }
             }
         }

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -13,7 +13,7 @@
                 "data": {
                     "host": "Host",
                     "port": "Port",
-                    "password": "Solutions Series: RSC+ Passcode\nOther Panels: Automation Passcode"
+                    "password": "Automation Passcode \\ RSC+ Passcode"
                 }
             }
         }


### PR DESCRIPTION
Had a few people ask how to find the port or the automation passcode on their solution panels, so I figure it makes sense to specify a default port and add RSC+ passcode to the translation strings