### PR TITLE
Display the panels firmware version instead of the protocol version

### DIFF
--- a/custom_components/bosch_alarm/device.py
+++ b/custom_components/bosch_alarm/device.py
@@ -8,5 +8,5 @@ def device_info_from_panel(panel):
         name=f"Bosch {panel.model}",
         manufacturer="Bosch Security Systems",
         model=panel.model,
-        sw_version=panel.protocol_version,
+        sw_version=panel.firmware_version,
     )


### PR DESCRIPTION
Relies on the following changes: https://github.com/mag1024/bosch-alarm-mode2/pull/17

Bosch have requested this, and there are a few open issues where this has confused users as well.