### PR TITLE
Revert "Display the panels firmware version instead of the protocol v…

### DIFF
--- a/custom_components/bosch_alarm/device.py
+++ b/custom_components/bosch_alarm/device.py
@@ -8,5 +8,5 @@ def device_info_from_panel(panel):
         name=f"Bosch {panel.model}",
         manufacturer="Bosch Security Systems",
         model=panel.model,
-        sw_version=panel.firmware_version,
+        sw_version=panel.protocol_version,
     )


### PR DESCRIPTION
…ersion (#14)"

This reverts commit a7a76d449686b1da79da611690429cd6206df7fa.

Oops, shouldn't've merged this before https://github.com/mag1024/bosch-alarm-mode2/pull/17