### PR TITLE
Add support for AMAX panels

### DIFF
--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -62,7 +62,6 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     _LOGGER.debug("Migrating from version %s", config_entry.version)
     if config_entry.version == 1:
         new = {**config_entry.data}
-
         # Solution panels previously put the user code in the password field
         # But now its in the user code field
         if "Solution" in config_entry.title:

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -60,9 +60,7 @@ async def options_update_listener(
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Migrate old entry."""
     _LOGGER.debug("Migrating from version %s", config_entry.version)
-
     if config_entry.version == 1:
-
         new = {**config_entry.data}
 
         # Solution panels previously put the user code in the password field

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -35,6 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except asyncio.exceptions.TimeoutError:
         _LOGGER.warning("Initial panel connection timed out...")
     except (ValueError, PermissionError) as ex:
+        await panel.disconnect()
         raise ConfigEntryAuthFailed(ex) from ex
     except:
         logging.exception("Initial panel connection failed")

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -18,9 +18,9 @@ from homeassistant.const import (
 
 import bosch_alarm_mode2
 
-from .const import DOMAIN, CONF_INSTALLER_CODE
+from .const import DOMAIN, CONF_INSTALLER_CODE, CONF_USER_CODE
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.ALARM_CONTROL_PANEL, Platform.SENSOR, 
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.ALARM_CONTROL_PANEL, Platform.SENSOR,
                              Platform.SWITCH]
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,8 +28,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Bosch Alarm from a config entry."""
     panel = bosch_alarm_mode2.Panel(
             host=entry.data[CONF_HOST], port=entry.data[CONF_PORT],
-            automation_code=entry.data[CONF_PASSWORD],
-            installer_code=entry.data.get(CONF_INSTALLER_CODE, None))
+            automation_code=entry.data.get(CONF_PASSWORD, None),
+            installer_or_user_code=entry.data.get(CONF_INSTALLER_CODE, entry.data.get(CONF_USER_CODE, None)))
     try:
         await panel.connect()
     except asyncio.exceptions.TimeoutError:
@@ -60,6 +60,27 @@ async def options_update_listener(
 ):
     """Handle options update."""
     await hass.config_entries.async_reload(config_entry.entry_id)
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    if config_entry.version == 1:
+
+        new = {**config_entry.data}
+
+        # Solution panels previously put the user code in the password field
+        # But now its in the user code field
+        if "Solution" in config_entry.title:
+            new[CONF_USER_CODE] = new[CONF_PASSWORD]
+            new.pop(CONF_PASSWORD)
+
+        config_entry.version = 2
+        hass.config_entries.async_update_entry(config_entry, data=new)
+
+    _LOGGER.debug("Migration to version %s successful", config_entry.version)
+
+    return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 
 import bosch_alarm_mode2
 
-from .const import DOMAIN
+from .const import DOMAIN, CONF_INSTALLER_CODE
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.ALARM_CONTROL_PANEL, Platform.SENSOR, 
                              Platform.SWITCH]
@@ -27,7 +27,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Bosch Alarm from a config entry."""
     panel = bosch_alarm_mode2.Panel(
             host=entry.data[CONF_HOST], port=entry.data[CONF_PORT],
-            passcode=entry.data[CONF_PASSWORD])
+            automation_code=entry.data[CONF_PASSWORD], 
+            installer_code=entry.data.get(CONF_INSTALLER_CODE, None))
     try:
         await panel.connect()
     except asyncio.exceptions.TimeoutError:

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -33,10 +33,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await panel.connect()
     except asyncio.exceptions.TimeoutError:
         _LOGGER.warning("Initial panel connection timed out...")
-    except ValueError:
-        logging.exception(
-            "Error with credentials. If you have just updated, you may need to delete your panel and add it again."
-        )
+    except ValueError as e:
+        raise e
     except:
         logging.exception("Initial panel connection failed")
 

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -33,6 +33,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await panel.connect()
     except asyncio.exceptions.TimeoutError:
         _LOGGER.warning("Initial panel connection timed out...")
+    except ValueError:
+        logging.exception(
+            "Error with credentials. If you have just updated, you may need to delete your panel and add it again."
+        )
     except:
         logging.exception("Initial panel connection failed")
 

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -8,7 +8,6 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from homeassistant.const import (
     CONF_HOST,
@@ -34,9 +33,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await panel.connect()
     except asyncio.exceptions.TimeoutError:
         _LOGGER.warning("Initial panel connection timed out...")
-    except (ValueError, PermissionError) as ex:
-        await panel.disconnect()
-        raise ConfigEntryAuthFailed(ex) from ex
     except:
         logging.exception("Initial panel connection failed")
 

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -11,7 +11,6 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant.const import (

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -71,7 +71,7 @@ async def try_connect(hass: HomeAssistant, data: dict[str, Any], load_selector: 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
     panel = Panel(host=data[CONF_HOST], port=data[CONF_PORT],
-                  automation_code=data[CONF_PASSWORD], installer_or_user_code=data.get(CONF_INSTALLER_CODE, None)) 
+                  automation_code=data.get(CONF_PASSWORD, None), installer_or_user_code=data.get(CONF_INSTALLER_CODE, data.get(CONF_USER_CODE, None))) 
     
     try:
         await panel.connect(load_selector)

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -132,7 +132,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reauth(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-       return self.async_step_user(user_input)
+       return await self.async_step_user(user_input)
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -49,7 +49,7 @@ STEP_AUTH_DATA_SCHEMA_AMAX = vol.Schema(
     }
 )
 
-STEP_AUTH_DATA_SCHEMA = vol.Schema(
+STEP_AUTH_DATA_SCHEMA_BG = vol.Schema(
     {
         vol.Required(CONF_PASSWORD): str,
     }
@@ -69,7 +69,8 @@ async def try_connect(hass: HomeAssistant, data: dict[str, Any], load_selector: 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
     panel = Panel(host=data[CONF_HOST], port=data[CONF_PORT],
-                  automation_code=data.get(CONF_PASSWORD, None), installer_or_user_code=data.get(CONF_INSTALLER_CODE, data.get(CONF_USER_CODE, None)))
+                  automation_code=data.get(CONF_PASSWORD, None), 
+                  installer_or_user_code=data.get(CONF_INSTALLER_CODE, data.get(CONF_USER_CODE, None)))
 
     try:
         await panel.connect(load_selector)
@@ -110,6 +111,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA
             )
         try:
+            # Use load_selector = 0 to fetch the panel model without authentication. 
             (model, _) = await try_connect(self.hass, user_input, 0)
             self.model = model
             self.data = user_input
@@ -130,7 +132,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         elif "AMAX" in self.model:
             schema = STEP_AUTH_DATA_SCHEMA_AMAX
         else:
-            schema = STEP_AUTH_DATA_SCHEMA
+            schema = STEP_AUTH_DATA_SCHEMA_BG
 
         if user_input is None:
             return self.async_show_form(

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -59,7 +59,7 @@ STEP_INIT_DATA_SCHEMA = vol.Schema(
     }
 )
 
-async def try_connect(hass: HomeAssistant, load_selector: int, data: dict[str, Any]):
+async def try_connect(hass: HomeAssistant, data: dict[str, Any]):
     """Validate the user input allows us to connect.
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
@@ -69,7 +69,7 @@ async def try_connect(hass: HomeAssistant, load_selector: int, data: dict[str, A
     errors = {}
 
     try:
-        await panel.connect(load_selector)
+        await panel.connect(Panel.LOAD_BASIC_INFO)
     except (PermissionError, ValueError):
         errors["base"] = "invalid_auth"
     except (OSError, ConnectionRefusedError, ssl.SSLError, asyncio.exceptions.TimeoutError):
@@ -103,7 +103,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         if "entry_id" in self.context:
             entry = self.hass.config_entries.async_get_entry(
-            self.context["entry_id"]
+                self.context["entry_id"]
             )
             if user_input is None:
                 user_input = entry.data
@@ -112,7 +112,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA
             )
         try:
-            (model, serial_number) = await try_connect(self.hass, Panel.LOAD_BASIC_INFO, user_input)
+            (model, serial_number) = await try_connect(self.hass, user_input)
             if "entry_id" in self.context:
                 entry = self.hass.config_entries.async_get_entry(
                     self.context["entry_id"]

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -89,10 +89,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(serial_number)
             self._abort_if_unique_id_configured()
             return self.async_create_entry(title="Bosch %s" % model, data=user_input)
+        except (PermissionError, ValueError):
+            errors["base"] = "invalid_auth"
         except (OSError, ConnectionRefusedError, ssl.SSLError, asyncio.exceptions.TimeoutError):
             errors["base"] = "cannot_connect"
-        except PermissionError:
-            errors["base"] = "invalid_auth"
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -126,7 +126,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title="Bosch %s" % model, data=user_input)
         except Exception as ex:
             return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=ex.args
+                step_id="user", data_schema=self.add_suggested_values_to_schema(
+                    STEP_USER_DATA_SCHEMA, user_input
+                ), errors=ex.args
             )
 
     async def async_step_reauth(

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -24,7 +24,8 @@ from homeassistant.const import (
 from bosch_alarm_mode2 import Panel
 
 from .const import (
-    DOMAIN
+    DOMAIN,
+    CONF_INSTALLER_CODE
 )
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_PORT, default=7700): cv.positive_int,
         vol.Required(CONF_PASSWORD): str,
+        vol.Optional(CONF_INSTALLER_CODE): str,
     }
 )
 
@@ -50,7 +52,7 @@ async def try_connect(hass: HomeAssistant, data: dict[str, Any]):
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
     panel = Panel(host=data[CONF_HOST], port=data[CONF_PORT],
-                  passcode=data[CONF_PASSWORD])
+                  automation_code=data[CONF_PASSWORD], installer_code=data.get(CONF_INSTALLER_CODE, None))
     try:
         await panel.connect(Panel.LOAD_BASIC_INFO)
     finally:

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -38,19 +38,6 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
-STEP_CODE_AUTH_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_PASSWORD): str,
-        vol.Required(CONF_INSTALLER_CODE): str,
-    }
-)
-
-STEP_AUTOMATION_AUTH_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_PASSWORD): str,
-    }
-)
-
 STEP_INIT_DATA_SCHEMA = vol.Schema(
     {
         vol.Optional(

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -110,7 +110,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA
             )
         try:
-            (model, _) = await try_connect(self.hass, user_input, Panel.LOAD_NO_AUTH)
+            (model, _) = await try_connect(self.hass, user_input, 0)
             self.model = model
             self.data = user_input
             return await self.async_step_auth()
@@ -138,7 +138,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
         self.data.update(user_input)
         try:
-            (model, serial_number) = await try_connect(self.hass, self.data, Panel.LOAD_BASIC_INFO)
+            (model, serial_number) = await try_connect(self.hass, self.data, Panel.LOAD_EXTENDED_INFO)
             await self.async_set_unique_id(serial_number)
             self._abort_if_unique_id_configured()
             return self.async_create_entry(title="Bosch %s" % model, data=self.data)

--- a/custom_components/bosch_alarm/const.py
+++ b/custom_components/bosch_alarm/const.py
@@ -1,6 +1,6 @@
 """Constants for the Bosch Alarm integration."""
 
-DOMAIN = "bosch_alarm"
+DOMAIN = 'bosch_alarm'
 HISTORY_ATTR = 'history'
 CONF_INSTALLER_CODE = 'installer_code'
 CONF_USER_CODE = 'user_code'

--- a/custom_components/bosch_alarm/const.py
+++ b/custom_components/bosch_alarm/const.py
@@ -3,3 +3,4 @@
 DOMAIN = "bosch_alarm"
 HISTORY_ATTR = 'history'
 CONF_INSTALLER_CODE = 'installer_code'
+CONF_USER_CODE = 'user_code'

--- a/custom_components/bosch_alarm/const.py
+++ b/custom_components/bosch_alarm/const.py
@@ -2,3 +2,4 @@
 
 DOMAIN = "bosch_alarm"
 HISTORY_ATTR = 'history'
+CONF_INSTALLER_CODE = 'installer_code'

--- a/custom_components/bosch_alarm/manifest.json
+++ b/custom_components/bosch_alarm/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/bosch_alarm",
-  "requirements": ["bosch-alarm-mode2==0.3.27"],
+  "requirements": ["bosch-alarm-mode2==0.3.28"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/bosch_alarm/manifest.json
+++ b/custom_components/bosch_alarm/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/bosch_alarm",
-  "requirements": ["bosch-alarm-mode2==0.3.26"],
+  "requirements": ["bosch-alarm-mode2==0.3.27"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -17,7 +17,7 @@
                     "password": "Automation code",
                     "installer_code": "Installer Code"
                 },
-                "description": "For Solution and AMAX panels, provide both your Automation Code and Installer Code.\nFor other panels, provide just your Automation Code.\nNote that your Automation Code needs to be at least 10 characters long, otherwise you won't be able to connect to your panel."
+                "description": "For Solution and AMAX panels, provide both your Automation Code and Installer Code.\nFor other panels, provide just your Automation Code.\nNote that your Automation Code needs to be at least 10 characters long, otherwise you won't be able to connect to your panel. \nThe Automation code can be set in A-Link or RPS."
             }
         }
     },

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -15,9 +15,9 @@
                     "host": "Host",
                     "port": "Port",
                     "password": "Automation code",
-                    "installer_code": "Installer Code (Solution / AMAX only)"
+                    "installer_code": "Installer Code"
                 },
-                "description": "Provide panel configuration here.\nFor Solution and AMAX panels, provide both your Automation Code and Installer Code.\nFor other panels, provide just your Automation Code."
+                "description": "For Solution and AMAX panels, provide both your Automation Code and Installer Code.\nFor other panels, provide just your Automation Code.\nNote that your Automation Code needs to be at least 10 characters long, otherwise you won't be able to connect to your panel."
             }
         }
     },

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -13,11 +13,20 @@
             "user": {
                 "data": {
                     "host": "Host",
-                    "port": "Port",
+                    "port": "Port"
+                }
+            },
+            "auth": {
+                "data": {
                     "password": "Automation code",
-                    "installer_code": "Installer code"
+                    "installer_code": "Installer code",
+                    "user_code": "User code"
                 },
-                "description": "For Solution and AMAX panels, provide both your automation code and installer code.\nFor other panels, provide just your automation code.\nNote that your automation code needs to be at least 10 characters long, otherwise you won't be able to connect to your panel. \nThe automation code can be set in A-Link or RPS.\nYour installer code should have been provided by whoever set up your panel."
+                "data_description": {
+                    "password": "The Automation Code is required to access all panels using the Mode 2 protocol. It can be configured via the A-Link Plus or the Remote Programming Software (RPS). It needs to be set to a string that is at least 10 characters.",
+                    "installer_code": "The Installer Code is used to access the configuration interface. Typically, it is a 4 digit numeric pin.",
+                    "user_code": "The User Code is the code used to arm the panel. Typically, it is a 4 digit numeric pin."
+                }
             }
         }
     },
@@ -30,7 +39,9 @@
                 "data": {
                     "code": "Arming code"
                 },
-                "description": "Specify an arming code if you wish to require a code for arming and disarming.\nThis code does not need to be related to any codes already set on your panel."
+                "data_description": {
+                    "code": "The arming code is used to protect the arm/disarm operations locally within Home Assistant. It does not have to match any of the codes configured in the panel."
+                }
             }
         }
     }

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -13,7 +13,8 @@
                 "data": {
                     "host": "Host",
                     "port": "Port",
-                    "password": "Automation Passcode \\ RSC+ Passcode"
+                    "password": "Automation Passcode",
+                    "installer_code": "Installer Code (Solution / AMAX only)"
                 }
             }
         }

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -16,7 +16,8 @@
                     "port": "Port",
                     "password": "Automation code",
                     "installer_code": "Installer Code (Solution / AMAX only)"
-                }
+                },
+                "description": "Provide panel configuration here.\nFor Solution and AMAX panels, provide both your Automation Code and Installer Code.\nFor other panels, provide just your Automation Code."
             }
         }
     },

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -17,12 +17,6 @@
                     "password": "Automation code",
                     "installer_code": "Installer Code (Solution / AMAX only)"
                 }
-            },
-            "reauth": {
-                "data": {
-                    "password": "Automation code",
-                    "installer_code": "Installer Code (Solution / AMAX only)"
-                }
             }
         }
     },

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reauth_successful": "Device successfully reconfigured"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -10,6 +11,14 @@
         },
         "step": {
             "user": {
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "password": "Automation Passcode",
+                    "installer_code": "Installer Code (Solution / AMAX only)"
+                }
+            },
+            "reauth": {
                 "data": {
                     "host": "Host",
                     "port": "Port",

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -15,7 +15,7 @@
                     "host": "Host",
                     "port": "Port",
                     "password": "Automation code",
-                    "installer_code": "Installer Code"
+                    "installer_code": "Installer code"
                 },
                 "description": "For Solution and AMAX panels, provide both your automation code and installer code.\nFor other panels, provide just your automation code.\nNote that your automation code needs to be at least 10 characters long, otherwise you won't be able to connect to your panel. \nThe automation code can be set in A-Link or RPS.\nYour installer code should have been provided by whoever set up your panel."
             }
@@ -28,8 +28,9 @@
         "step": {
             "init": {
                 "data": {
-                    "code": "Arming Code"
-                }
+                    "code": "Arming code"
+                },
+                "description": "Specify an arming code if you wish to require a code for arming and disarming.\nThis code does not need to be related to any codes already set on your panel."
             }
         }
     }

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -17,7 +17,7 @@
                     "password": "Automation code",
                     "installer_code": "Installer Code"
                 },
-                "description": "For Solution and AMAX panels, provide both your Automation Code and Installer Code.\nFor other panels, provide just your Automation Code.\nNote that your Automation Code needs to be at least 10 characters long, otherwise you won't be able to connect to your panel. \nThe Automation code can be set in A-Link or RPS."
+                "description": "For Solution and AMAX panels, provide both your automation code and installer code.\nFor other panels, provide just your automation code.\nNote that your automation code needs to be at least 10 characters long, otherwise you won't be able to connect to your panel. \nThe automation code can be set in A-Link or RPS.\nYour installer code should have been provided by whoever set up your panel."
             }
         }
     },

--- a/custom_components/bosch_alarm/translations/en.json
+++ b/custom_components/bosch_alarm/translations/en.json
@@ -14,15 +14,13 @@
                 "data": {
                     "host": "Host",
                     "port": "Port",
-                    "password": "Automation Passcode",
+                    "password": "Automation code",
                     "installer_code": "Installer Code (Solution / AMAX only)"
                 }
             },
             "reauth": {
                 "data": {
-                    "host": "Host",
-                    "port": "Port",
-                    "password": "Automation Passcode",
+                    "password": "Automation code",
                     "installer_code": "Installer Code (Solution / AMAX only)"
                 }
             }


### PR DESCRIPTION
Require a separate installer code and automation code for Solution and AMAX panels
I've also implemented the reauth handler, so that users will get a notifcation that they need to reenter credentials

Also changed the config dialog to have more information on the various codes.

![image](https://github.com/mag1024/bosch-alarm-homeassistant/assets/1862720/7d8462f2-824f-4475-845b-8efa0f5b2f46)

I've changed the options dialog too
![image](https://github.com/mag1024/bosch-alarm-homeassistant/assets/1862720/151bdda0-1e41-42ec-9e35-9b1241e6159d)

