### PR TITLE
Fix issues with unique IDs

### DIFF
--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -40,6 +40,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = panel
 
     def setup():
+        if not panel.serial_number:
+            panel.serial_number = entry.entry_id
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setups(entry, PLATFORMS))
     if panel.connection_status():

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -41,6 +41,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = panel
 
     def setup():
+        # Some panels don't support retrieving a serial number.
+        # We still need some form of identifier, so fall back
+        # to the entry id.
         if not panel.serial_number:
             panel.serial_number = entry.entry_id
 

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -49,9 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         # Remove old devices using the panel model as an identifier
         dr = device_registry.async_get(hass)
-        for device_entry in device_registry.async_entries_for_config_entry(
-            dr, entry.entry_id
-        ):
+        for device_entry in device_registry.async_entries_for_config_entry(dr, entry.entry_id):
             if (DOMAIN, panel.model) in device_entry.identifiers:
                 dr.async_remove_device(device_entry.id)
 

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -50,7 +50,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Remove old devices using the panel model as an identifier
         dr = device_registry.async_get(hass)
         for device_entry in device_registry.async_entries_for_config_entry(
-            device_registry, entry.entry_id
+            dr, entry.entry_id
         ):
             if (DOMAIN, panel.model) in device_entry.identifiers:
                 dr.async_remove_device(device_entry.id)

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -8,7 +8,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry
 
 from homeassistant.const import (
     CONF_HOST,
@@ -48,12 +48,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             panel.serial_number = entry.entry_id
 
         # Remove old devices using the panel model as an identifier
-        device_registry = dr.async_get(hass)
-        for device_entry in dr.async_entries_for_config_entry(
+        dr = device_registry.async_get(hass)
+        for device_entry in device_registry.async_entries_for_config_entry(
             device_registry, entry.entry_id
         ):
-            if (DOMAIN,panel.model) in device_entry.identifiers:
-                device_registry.async_remove_device(device_entry.id)
+            if (DOMAIN, panel.model) in device_entry.identifiers:
+                dr.async_remove_device(device_entry.id)
 
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setups(entry, PLATFORMS))

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -8,6 +8,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from homeassistant.const import (
     CONF_HOST,
@@ -42,6 +43,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     def setup():
         if not panel.serial_number:
             panel.serial_number = entry.entry_id
+
+        # Remove old devices using the panel model as an identifier
+        device_registry = dr.async_get(hass)
+        for device_entry in dr.async_entries_for_config_entry(
+            device_registry, entry.entry_id
+        ):
+            if (DOMAIN,panel.model) in device_entry.identifiers:
+                device_registry.async_remove_device(device_entry.id)
+
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setups(entry, PLATFORMS))
     if panel.connection_status():

--- a/custom_components/bosch_alarm/device.py
+++ b/custom_components/bosch_alarm/device.py
@@ -4,7 +4,7 @@ from .const import DOMAIN
 
 def device_info_from_panel(panel):
     return DeviceInfo(
-        identifiers={(DOMAIN, panel.serial_number or panel.model)},
+        identifiers={(DOMAIN, panel.serial_number)},
         name=f"Bosch {panel.model}",
         manufacturer="Bosch Security Systems",
         model=panel.model,


### PR DESCRIPTION
Closes https://github.com/mag1024/bosch-alarm-homeassistant/issues/21

When generating unique ids for the entities, use the config entry id if the serial number is not available

Also, don't treat the panels model as a identifier, someone may have more than one panel with the same model!