### PR TITLE
Resolve "Issues with entry unloading"

### DIFF
--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -40,28 +40,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = panel
 
-    def setup():
-        # Some panels don't support retrieving a serial number.
-        # We still need some form of identifier, so fall back
-        # to the entry id.
-        if not panel.serial_number:
-            panel.serial_number = entry.entry_id
+    # We store the serial number as the unique id
+    # If the panel doesn't expose it's serial number, use the entry id as a unique id instead.
+    panel.serial_number = entry.unique_id or entry.entry_id
 
-        # Remove old devices using the panel model as an identifier
-        dr = device_registry.async_get(hass)
-        for device_entry in device_registry.async_entries_for_config_entry(dr, entry.entry_id):
-            if (DOMAIN, panel.model) in device_entry.identifiers:
-                dr.async_remove_device(device_entry.id)
-
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setups(entry, PLATFORMS))
-    if panel.connection_status():
-        setup()
-    else:
-        panel.connection_status_observer.attach(
-                lambda: panel.connection_status() and setup())
+    # Remove old devices using the panel model as an identifier
+    # We use the panels model as the entries title
+    panel.model = entry.title.replace("Bosch ","")
+    dr = device_registry.async_get(hass)
+    for device_entry in device_registry.async_entries_for_config_entry(dr, entry.entry_id):
+        if (DOMAIN, panel.model) in device_entry.identifiers:
+            dr.async_remove_device(device_entry.id)
 
     entry.async_on_unload(entry.add_update_listener(options_update_listener))
+
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setups(entry, PLATFORMS))
     return True
 
 async def options_update_listener(

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -38,10 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # If the panel doesn't expose it's serial number, use the entry id as a unique id instead.
     unique_id = entry.unique_id or entry.entry_id
 
-    # The config flow sets the entries title to the panel's model
-    model = entry.title.replace("Bosch ","")
-
-    data = PanelConnection(panel, unique_id, model)
+    data = PanelConnection(panel, unique_id, entry.data[CONF_MODEL])
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = data

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -44,9 +44,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # If the panel doesn't expose it's serial number, use the entry id as a unique id instead.
     panel.serial_number = entry.unique_id or entry.entry_id
 
-    # Remove old devices using the panel model as an identifier
     # We use the panels model as the entries title
     panel.model = entry.title.replace("Bosch ","")
+
+    # Remove old devices using the panel model as an identifier
     dr = device_registry.async_get(hass)
     for device_entry in device_registry.async_entries_for_config_entry(dr, entry.entry_id):
         if (DOMAIN, panel.model) in device_entry.identifiers:

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -47,7 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setups(entry, PLATFORMS))
-    entry.async_create_background_task(hass, panel.connect(), "panel_conn")
+    entry.async_create_background_task(hass, panel.connect(), "panel_connection")
     return True
 
 async def options_update_listener(

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # If the panel doesn't expose it's serial number, use the entry id as a unique id instead.
     unique_id = entry.unique_id or entry.entry_id
 
-    # The config flow sets the entrie's title to the panel's model
+    # The config flow sets the entries title to the panel's model
     model = entry.title.replace("Bosch ","")
 
     data = BoschPanel(panel, unique_id, model)

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -18,6 +18,8 @@ from homeassistant.const import (
 
 import bosch_alarm_mode2
 
+from .device import BoschPanel
+
 from .const import DOMAIN, CONF_INSTALLER_CODE, CONF_USER_CODE
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.ALARM_CONTROL_PANEL, Platform.SENSOR,
@@ -30,10 +32,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             host=entry.data[CONF_HOST], port=entry.data[CONF_PORT],
             automation_code=entry.data.get(CONF_PASSWORD, None),
             installer_or_user_code=entry.data.get(CONF_INSTALLER_CODE, entry.data.get(CONF_USER_CODE, None)))
-    entry.async_create_background_task(hass, panel.connect(), "connection")
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = panel
+    hass.data[DOMAIN][entry.entry_id] = BoschPanel(panel)
 
     # We store the serial number as the unique id
     # If the panel doesn't expose it's serial number, use the entry id as a unique id instead.
@@ -52,6 +53,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setups(entry, PLATFORMS))
+
+    entry.async_create_background_task(hass, panel.connect(), "connection")
+
     return True
 
 async def options_update_listener(

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -66,11 +66,12 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         if "Solution" in config_entry.title:
             new[CONF_USER_CODE] = new[CONF_PASSWORD]
             new.pop(CONF_PASSWORD)
-        dr = device_registry.async_get(hass)
 
     if config_entry.version < 3:
-        # Remove old devices using the panel model as an identifier
         model = config_entry.title.replace("Bosch ", "")
+        
+        # Remove old devices using the panel model as an identifier
+        dr = device_registry.async_get(hass)
         for device_entry in device_registry.async_entries_for_config_entry(dr, config_entry.entry_id):
             if (DOMAIN, model) in device_entry.identifiers:
                 dr.async_remove_device(device_entry.id)

--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -30,12 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             host=entry.data[CONF_HOST], port=entry.data[CONF_PORT],
             automation_code=entry.data.get(CONF_PASSWORD, None),
             installer_or_user_code=entry.data.get(CONF_INSTALLER_CODE, entry.data.get(CONF_USER_CODE, None)))
-    try:
-        await panel.connect()
-    except asyncio.exceptions.TimeoutError:
-        _LOGGER.warning("Initial panel connection timed out...")
-    except:
-        logging.exception("Initial panel connection failed")
+    entry.async_create_background_task(hass, panel.connect(), "connection")
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = panel

--- a/custom_components/bosch_alarm/alarm_control_panel.py
+++ b/custom_components/bosch_alarm/alarm_control_panel.py
@@ -38,14 +38,14 @@ SET_DATE_TIME_SCHEMA = make_entity_service_schema({
 })
 
 class AreaAlarmControlPanel(AlarmControlPanelEntity):
-    def __init__(self, panel, arming_code, area_id, area, unique_id):
-        self._panel = panel
+    def __init__(self, data, arming_code, area_id, area, unique_id):
+        self._panel = data.panel
         self._area_id = area_id
         self._area = area
         self._unique_id = unique_id
         self._arming_code = arming_code
         self._attr_has_entity_name = True
-        self._attr_device_info = device_info_from_panel(panel)
+        self._attr_device_info = device_info_from_panel(data)
 
     @property
     def code_format(self) -> alarm.CodeFormat | None:
@@ -126,7 +126,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     def setup():
         async_add_entities(
-            AreaAlarmControlPanel(panel, arming_code, id, area, f'{panel.serial_number}_area_{id}')
+            AreaAlarmControlPanel(data, arming_code, id, area, f'{data.unique_id}_area_{id}')
                 for (id, area) in panel.areas.items())
 
     data.register_entity_setup(setup)

--- a/custom_components/bosch_alarm/alarm_control_panel.py
+++ b/custom_components/bosch_alarm/alarm_control_panel.py
@@ -31,12 +31,13 @@ class AreaAlarmControlPanel(AlarmControlPanelEntity):
         self._area = area
         self._unique_id = unique_id
         self._arming_code = arming_code
+        self._attr_has_entity_name = True
         self._attr_device_info = device_info_from_panel(panel)
-    
+
     @property
     def code_format(self) -> alarm.CodeFormat | None:
         """Return one or more digits/characters."""
-        if self._arming_code is None: 
+        if self._arming_code is None:
             return None
         if self._arming_code.isnumeric():
             return alarm.CodeFormat.NUMBER
@@ -66,18 +67,18 @@ class AreaAlarmControlPanel(AlarmControlPanelEntity):
             AlarmControlPanelEntityFeature.ARM_HOME
             | AlarmControlPanelEntityFeature.ARM_AWAY
         )
-    
+
     def _arming_code_correct(self, code) -> bool:
         return code == self._arming_code
 
     async def async_alarm_disarm(self, code=None) -> None:
-        if self._arming_code_correct(code): 
+        if self._arming_code_correct(code):
             await self._panel.area_disarm(self._area_id)
     async def async_alarm_arm_home(self, code=None) -> None:
-        if self._arming_code_correct(code): 
+        if self._arming_code_correct(code):
             await self._panel.area_arm_part(self._area_id)
     async def async_alarm_arm_away(self, code=None) -> None:
-        if self._arming_code_correct(code): 
+        if self._arming_code_correct(code):
             await self._panel.area_arm_all(self._area_id)
 
     @property

--- a/custom_components/bosch_alarm/alarm_control_panel.py
+++ b/custom_components/bosch_alarm/alarm_control_panel.py
@@ -119,12 +119,17 @@ class AreaAlarmControlPanel(AlarmControlPanelEntity):
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up control panels for each area."""
-    panel = hass.data[DOMAIN][config_entry.entry_id]
+    data = hass.data[DOMAIN][config_entry.entry_id]
+    panel = data.panel
 
     arming_code = config_entry.options.get(CONF_CODE, None)
-    async_add_entities(
+
+    def setup():
+        async_add_entities(
             AreaAlarmControlPanel(panel, arming_code, id, area, f'{panel.serial_number}_area_{id}')
                 for (id, area) in panel.areas.items())
+
+    data.register_entity_setup(setup)
 
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(SET_DATE_TIME_SERVICE_NAME, SET_DATE_TIME_SCHEMA, "set_panel_date")

--- a/custom_components/bosch_alarm/alarm_control_panel.py
+++ b/custom_components/bosch_alarm/alarm_control_panel.py
@@ -39,10 +39,10 @@ SET_DATE_TIME_SCHEMA = make_entity_service_schema({
 class AreaAlarmControlPanel(AlarmControlPanelEntity):
     def __init__(self, panel_conn, arming_code, area_id, area, unique_id):
         self._panel = panel_conn.panel
+        self._arming_code = arming_code
         self._area_id = area_id
         self._area = area
         self._attr_unique_id = unique_id
-        self._arming_code = arming_code
         self._attr_has_entity_name = True
         self._attr_device_info = panel_conn.device_info()
 

--- a/custom_components/bosch_alarm/binary_sensor.py
+++ b/custom_components/bosch_alarm/binary_sensor.py
@@ -70,11 +70,11 @@ class PointSensor(PanelBinarySensor):
         return _guess_device_class(self.name.lower())
 
 class ConnectionStatusSensor(PanelBinarySensor):
-    def __init__(self, panel, unique_id):
+    def __init__(self, data, unique_id):
         PanelBinarySensor.__init__(
-                self, panel.connection_status_observer, unique_id,
-                device_info_from_panel(panel))
-        self._panel = panel
+                self, data.panel.connection_status_observer, unique_id,
+                device_info_from_panel(data))
+        self._panel = data.panel
 
     @property
     def name(self): return f"Connection Status"
@@ -94,11 +94,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     async_add_entities(
             [ConnectionStatusSensor(
-                panel, f'{panel.serial_number}_connection_status')])
+                data, f'{data.unique_id}_connection_status')])
     def setup():
-        device_info = device_info_from_panel(panel)
+        device_info = device_info_from_panel(data)
         async_add_entities(
-                PointSensor(point, f'{panel.serial_number}_point_{id}', device_info)
+                PointSensor(point, f'{data.unique_id}_point_{id}', device_info)
                     for (id, point) in panel.points.items())
 
     data.register_entity_setup(setup)

--- a/custom_components/bosch_alarm/binary_sensor.py
+++ b/custom_components/bosch_alarm/binary_sensor.py
@@ -68,7 +68,7 @@ class PointSensor(PanelBinarySensor):
 class ConnectionStatusSensor(PanelBinarySensor):
     def __init__(self, panel_conn, unique_id):
         PanelBinarySensor.__init__(
-                self, panel_conn.panel.panel_conn_status_observer, unique_id,
+                self, panel_conn.panel.connection_status_observer, unique_id,
                 panel_conn.device_info())
         self._panel = panel_conn.panel
 
@@ -76,7 +76,7 @@ class ConnectionStatusSensor(PanelBinarySensor):
     def name(self): return "Connection Status"
 
     @property
-    def is_on(self): return self._panel.panel_conn_status()
+    def is_on(self): return self._panel.connection_status()
 
     @property
     def device_class(self): return BinarySensorDeviceClass.CONNECTIVITY
@@ -90,7 +90,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     async_add_entities(
             [ConnectionStatusSensor(
-                panel_conn, f'{panel_conn.unique_id}_panel_conn_status')])
+                panel_conn, f'{panel_conn.unique_id}_connection_status')])
     def setup():
         async_add_entities(
                 PointSensor(point, f'{panel_conn.unique_id}_point_{id}', panel_conn.device_info())

--- a/custom_components/bosch_alarm/binary_sensor.py
+++ b/custom_components/bosch_alarm/binary_sensor.py
@@ -34,6 +34,7 @@ class PanelBinarySensor(BinarySensorEntity):
     def __init__(self, observer, unique_id, device_info):
         self._observer = observer
         self._unique_id = unique_id
+        self._attr_has_entity_name = True
         self._attr_device_info = device_info
 
     @property
@@ -76,7 +77,7 @@ class ConnectionStatusSensor(PanelBinarySensor):
         self._panel = panel
 
     @property
-    def name(self): return f"{self._panel.model} Connection Status"
+    def name(self): return f"Connection Status"
 
     @property
     def is_on(self): return self._panel.connection_status()

--- a/custom_components/bosch_alarm/binary_sensor.py
+++ b/custom_components/bosch_alarm/binary_sensor.py
@@ -32,12 +32,9 @@ def _guess_device_class(name):
 class PanelBinarySensor(BinarySensorEntity):
     def __init__(self, observer, unique_id, device_info):
         self._observer = observer
-        self._unique_id = unique_id
-        self._attr_has_entity_name = True
+        self._attr_unique_id = unique_id
         self._attr_device_info = device_info
-
-    @property
-    def unique_id(self): return self._unique_id
+        self._attr_has_entity_name = True
 
     @property
     def should_poll(self): return False

--- a/custom_components/bosch_alarm/binary_sensor.py
+++ b/custom_components/bosch_alarm/binary_sensor.py
@@ -69,34 +69,34 @@ class PointSensor(PanelBinarySensor):
         return _guess_device_class(self.name.lower())
 
 class ConnectionStatusSensor(PanelBinarySensor):
-    def __init__(self, connection, unique_id):
+    def __init__(self, panel_conn, unique_id):
         PanelBinarySensor.__init__(
-                self, connection.panel.connection_status_observer, unique_id,
-                connection.device_info())
-        self._panel = connection.panel
+                self, panel_conn.panel.panel_conn_status_observer, unique_id,
+                panel_conn.device_info())
+        self._panel = panel_conn.panel
 
     @property
     def name(self): return "Connection Status"
 
     @property
-    def is_on(self): return self._panel.connection_status()
+    def is_on(self): return self._panel.panel_conn_status()
 
     @property
     def device_class(self): return BinarySensorDeviceClass.CONNECTIVITY
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up binary sensors for alarm points and the connection status."""
+    """Set up binary sensors for alarm points and the panel_conn status."""
 
-    connection = hass.data[DOMAIN][config_entry.entry_id]
-    panel = connection.panel
+    panel_conn = hass.data[DOMAIN][config_entry.entry_id]
+    panel = panel_conn.panel
 
     async_add_entities(
             [ConnectionStatusSensor(
-                connection, f'{connection.unique_id}_connection_status')])
+                panel_conn, f'{panel_conn.unique_id}_panel_conn_status')])
     def setup():
         async_add_entities(
-                PointSensor(point, f'{connection.unique_id}_point_{id}', connection.device_info())
+                PointSensor(point, f'{panel_conn.unique_id}_point_{id}', panel_conn.device_info())
                     for (id, point) in panel.points.items())
 
-    connection.on_connect.append(setup)
+    panel_conn.on_connect.append(setup)

--- a/custom_components/bosch_alarm/binary_sensor.py
+++ b/custom_components/bosch_alarm/binary_sensor.py
@@ -83,7 +83,7 @@ class ConnectionStatusSensor(PanelBinarySensor):
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up binary sensors for alarm points and the panel_conn status."""
+    """Set up binary sensors for alarm points and the connection status."""
 
     panel_conn = hass.data[DOMAIN][config_entry.entry_id]
     panel = panel_conn.panel

--- a/custom_components/bosch_alarm/binary_sensor.py
+++ b/custom_components/bosch_alarm/binary_sensor.py
@@ -89,12 +89,16 @@ class ConnectionStatusSensor(PanelBinarySensor):
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up binary sensors for alarm points and the connection status."""
 
-    panel = hass.data[DOMAIN][config_entry.entry_id]
+    data = hass.data[DOMAIN][config_entry.entry_id]
+    panel = data.panel
+
     async_add_entities(
             [ConnectionStatusSensor(
                 panel, f'{panel.serial_number}_connection_status')])
-    device_info = device_info_from_panel(panel)
-    async_add_entities(
-            PointSensor(point, f'{panel.serial_number}_point_{id}', device_info)
-                for (id, point) in panel.points.items())
+    def setup():
+        device_info = device_info_from_panel(panel)
+        async_add_entities(
+                PointSensor(point, f'{panel.serial_number}_point_{id}', device_info)
+                    for (id, point) in panel.points.items())
 
+    data.register_entity_setup(setup)

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -17,7 +17,8 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     CONF_PASSWORD,
-    CONF_CODE
+    CONF_CODE,
+    CONF_MODEL
 )
 
 from bosch_alarm_mode2 import Panel
@@ -92,10 +93,9 @@ async def try_connect(hass: HomeAssistant, data: dict[str, Any], load_selector: 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Bosch Alarm."""
 
-    VERSION = 2
+    VERSION = 3
     entry: config_entries.ConfigEntry | None = None
     data: dict[str, Any] | None = None
-    model: str | None = None
 
     @staticmethod
     @config_entries.callback
@@ -113,8 +113,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             # Use load_selector = 0 to fetch the panel model without authentication. 
             (model, _) = await try_connect(self.hass, user_input, 0)
-            self.model = model
             self.data = user_input
+            self.data[CONF_MODEL] = model
             return await self.async_step_auth()
         except RuntimeError as ex:
             _LOGGER.info(user_input)
@@ -127,9 +127,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the auth step."""
-        if "Solution" in self.model:
+        if "Solution" in self.data[CONF_MODEL]:
             schema = STEP_AUTH_DATA_SCHEMA_SOLUTION
-        elif "AMAX" in self.model:
+        elif "AMAX" in self.data[CONF_MODEL]:
             schema = STEP_AUTH_DATA_SCHEMA_AMAX
         else:
             schema = STEP_AUTH_DATA_SCHEMA_BG

--- a/custom_components/bosch_alarm/device.py
+++ b/custom_components/bosch_alarm/device.py
@@ -10,3 +10,24 @@ def device_info_from_panel(panel):
         model=panel.model,
         sw_version=panel.firmware_version,
     )
+
+class BoschPanel:
+    def __init__(self, panel):
+        self.panel = panel
+        self._initialised = False
+        self._entity_setups = []
+        panel.connection_status_observer.attach(self.setup)
+
+    def register_entity_setup(self, initializer):
+        self._entity_setups.append(initializer)
+
+    def setup(self):
+        if not self.panel.connection_status() or self._initialised:
+            return
+        self._initialised = True
+        for initializer in self._entity_setups:
+            initializer()
+
+    async def disconnect(self):
+        self.panel.connection_status_observer.detach(self.setup)
+        await self.panel.disconnect()

--- a/custom_components/bosch_alarm/device.py
+++ b/custom_components/bosch_alarm/device.py
@@ -2,31 +2,35 @@ from homeassistant.helpers.entity import DeviceInfo
 
 from .const import DOMAIN
 
-def device_info_from_panel(panel):
+def device_info_from_panel(data):
+    panel = data.panel
     return DeviceInfo(
-        identifiers={(DOMAIN, panel.serial_number)},
-        name=f"Bosch {panel.model}",
+        identifiers={(DOMAIN, data.unique_id)},
+        name=f"Bosch {data.model}",
         manufacturer="Bosch Security Systems",
         model=panel.model,
         sw_version=panel.firmware_version,
     )
 
 class BoschPanel:
-    def __init__(self, panel):
+    def __init__(self, panel, unique_id, model):
+        self.unique_id = unique_id
+        self.model = model
         self.panel = panel
         self._initialised = False
         self._entity_setups = []
         panel.connection_status_observer.attach(self.setup)
 
-    def register_entity_setup(self, initializer):
-        self._entity_setups.append(initializer)
+    def register_entity_setup(self, setup):
+        self._entity_setups.append(setup)
 
     def setup(self):
         if not self.panel.connection_status() or self._initialised:
             return
+        # We only want to setup entities once
         self._initialised = True
-        for initializer in self._entity_setups:
-            initializer()
+        for setup in self._entity_setups:
+            setup()
 
     async def disconnect(self):
         self.panel.connection_status_observer.detach(self.setup)

--- a/custom_components/bosch_alarm/device.py
+++ b/custom_components/bosch_alarm/device.py
@@ -4,14 +4,14 @@ from .const import DOMAIN
 
 class PanelConnection:
     def __init__(self, panel, unique_id, model):
+        self.panel = panel
         self.unique_id = unique_id
         self.model = model
-        self.panel = panel
         self.on_connect = []
-        panel.connection_status_observer.attach(self.on_connection_status_change)
+        panel.panel_conn_status_observer.attach(self.on_panel_conn_status_change)
 
-    def on_connection_status_change(self):
-        if not self.panel.connection_status():
+    def on_panel_conn_status_change(self):
+        if not self.panel.panel_conn_status():
             return
         for on_connect_handler in self.on_connect:
             on_connect_handler()
@@ -27,5 +27,5 @@ class PanelConnection:
         )
 
     async def disconnect(self):
-        self.panel.connection_status_observer.detach(self.on_connection_status_change)
+        self.panel.panel_conn_status_observer.detach(self.on_panel_conn_status_change)
         await self.panel.disconnect()

--- a/custom_components/bosch_alarm/device.py
+++ b/custom_components/bosch_alarm/device.py
@@ -2,36 +2,30 @@ from homeassistant.helpers.entity import DeviceInfo
 
 from .const import DOMAIN
 
-def device_info_from_panel(data):
-    panel = data.panel
-    return DeviceInfo(
-        identifiers={(DOMAIN, data.unique_id)},
-        name=f"Bosch {data.model}",
-        manufacturer="Bosch Security Systems",
-        model=panel.model,
-        sw_version=panel.firmware_version,
-    )
-
-class BoschPanel:
+class PanelConnection:
     def __init__(self, panel, unique_id, model):
         self.unique_id = unique_id
         self.model = model
         self.panel = panel
-        self._initialised = False
-        self._entity_setups = []
-        panel.connection_status_observer.attach(self.setup)
+        self.on_connect = []
+        panel.connection_status_observer.attach(self.on_connection_status_change)
 
-    def register_entity_setup(self, setup):
-        self._entity_setups.append(setup)
-
-    def setup(self):
-        if not self.panel.connection_status() or self._initialised:
+    def on_connection_status_change(self):
+        if not self.panel.connection_status():
             return
-        # We only want to setup entities once
-        self._initialised = True
-        for setup in self._entity_setups:
-            setup()
+        for on_connect_handler in self.on_connect:
+            on_connect_handler()
+        self.on_connect.clear()
+
+    def device_info(self):
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.unique_id)},
+            name=f"Bosch {self.model}",
+            manufacturer="Bosch Security Systems",
+            model=self.model,
+            sw_version=self.panel.firmware_version,
+        )
 
     async def disconnect(self):
-        self.panel.connection_status_observer.detach(self.setup)
+        self.panel.connection_status_observer.detach(self.on_connection_status_change)
         await self.panel.disconnect()

--- a/custom_components/bosch_alarm/device.py
+++ b/custom_components/bosch_alarm/device.py
@@ -8,10 +8,10 @@ class PanelConnection:
         self.unique_id = unique_id
         self.model = model
         self.on_connect = []
-        panel.panel_conn_status_observer.attach(self.on_panel_conn_status_change)
+        panel.connection_status_observer.attach(self._on_connection_status_change)
 
-    def on_panel_conn_status_change(self):
-        if not self.panel.panel_conn_status():
+    def _on_connection_status_change(self):
+        if not self.panel.connection_status():
             return
         for on_connect_handler in self.on_connect:
             on_connect_handler()
@@ -27,5 +27,5 @@ class PanelConnection:
         )
 
     async def disconnect(self):
-        self.panel.panel_conn_status_observer.detach(self.on_panel_conn_status_change)
+        self.panel.connection_status_observer.detach(self._on_connection_status_change)
         await self.panel.disconnect()

--- a/custom_components/bosch_alarm/sensor.py
+++ b/custom_components/bosch_alarm/sensor.py
@@ -13,10 +13,10 @@ from .const import DOMAIN, HISTORY_ATTR
 _LOGGER = logging.getLogger(__name__)
 
 class PanelSensor(SensorEntity):
-    def __init__(self, connection, observer):
-        self._panel = connection.panel
+    def __init__(self, panel_conn, observer):
+        self._panel = panel_conn.panel
         self._attr_has_entity_name = True
-        self._attr_device_info = connection.device_info()
+        self._attr_device_info = panel_conn.device_info()
         self._observer = observer
 
     @property
@@ -29,10 +29,10 @@ class PanelSensor(SensorEntity):
         self._observer.detach(self.schedule_update_ha_state)
 
 class PanelHistorySensor(PanelSensor):
-    def __init__(self, connection):
-        super().__init__(connection, connection.panel.history_observer)
+    def __init__(self, panel_conn):
+        super().__init__(panel_conn, panel_conn.panel.history_observer)
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self._attr_unique_id = f'{connection.unique_id}_history'
+        self._attr_unique_id = f'{panel_conn.unique_id}_history'
 
     @property
     def icon(self): return "mdi:history"
@@ -45,7 +45,7 @@ class PanelHistorySensor(PanelSensor):
         return "No events"
 
     @property
-    def name(self): return f"History"
+    def name(self): return "History"
 
     @property
     def extra_state_attributes(self):
@@ -53,9 +53,9 @@ class PanelHistorySensor(PanelSensor):
         return { HISTORY_ATTR + f'_{e.date}': e.message for e in events }
 
 class PanelFaultsSensor(PanelSensor):
-    def __init__(self, connection):
-        super().__init__(connection, connection.panel.faults_observer)
-        self._attr_unique_id = f'{connection.unique_id}_faults'
+    def __init__(self, panel_conn):
+        super().__init__(panel_conn, panel_conn.panel.faults_observer)
+        self._attr_unique_id = f'{panel_conn.unique_id}_faults'
 
     @property
     def icon(self): return "mdi:alert-circle"
@@ -66,11 +66,11 @@ class PanelFaultsSensor(PanelSensor):
         return "\n".join(faults) if faults else "No faults"
 
     @property
-    def name(self): return f"Faults"
+    def name(self): return "Faults"
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a sensor for tracking panel history."""
 
-    connection = hass.data[DOMAIN][config_entry.entry_id]
-    async_add_entities([PanelHistorySensor(connection), PanelFaultsSensor(connection)])
+    panel_conn = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities([PanelHistorySensor(panel_conn), PanelFaultsSensor(panel_conn)])
 

--- a/custom_components/bosch_alarm/sensor.py
+++ b/custom_components/bosch_alarm/sensor.py
@@ -23,7 +23,7 @@ class PanelSensor(SensorEntity):
 
     @property
     def should_poll(self): return False
-    
+
     async def async_added_to_hass(self):
         self._observer.attach(self.schedule_update_ha_state)
 
@@ -77,6 +77,6 @@ class PanelFaultsSensor(PanelSensor):
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up a sensor for tracking panel history."""
 
-    panel = hass.data[DOMAIN][config_entry.entry_id]
+    panel = hass.data[DOMAIN][config_entry.entry_id].panel
     async_add_entities([PanelHistorySensor(panel), PanelFaultsSensor(panel)])
 

--- a/custom_components/bosch_alarm/sensor.py
+++ b/custom_components/bosch_alarm/sensor.py
@@ -17,6 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 class PanelHistorySensor(SensorEntity):
     def __init__(self, panel):
         self._panel = panel
+        self._attr_has_entity_name = True
         self._attr_device_info = device_info_from_panel(panel)
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -37,13 +38,13 @@ class PanelHistorySensor(SensorEntity):
         return "No events"
 
     @property
-    def name(self): return f"{self._panel.model} History"
+    def name(self): return f"History"
 
     @property
     def extra_state_attributes(self):
         events = self._panel.events
         return { HISTORY_ATTR + f'_{e.date}': e.message for e in events }
-    
+
     async def async_added_to_hass(self):
         self._panel.history_observer.attach(self.schedule_update_ha_state)
 

--- a/custom_components/bosch_alarm/switch.py
+++ b/custom_components/bosch_alarm/switch.py
@@ -14,6 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 class PanelOutputEntity(SwitchEntity):
     def __init__(self, id, output, device_info, panel):
         self._observer = output.status_observer
+        self._attr_has_entity_name = True
         self._attr_device_info = device_info
         self._panel = panel
         self._id = id
@@ -34,7 +35,7 @@ class PanelOutputEntity(SwitchEntity):
     @property
     def is_on(self) -> bool:
         return self._output.is_active()
-    
+
     @property
     def name(self): return self._output.name
 

--- a/custom_components/bosch_alarm/switch.py
+++ b/custom_components/bosch_alarm/switch.py
@@ -12,16 +12,17 @@ from .device import device_info_from_panel
 _LOGGER = logging.getLogger(__name__)
 
 class PanelOutputEntity(SwitchEntity):
-    def __init__(self, id, output, device_info, panel):
+    def __init__(self, id, output, device_info, data):
         self._observer = output.status_observer
         self._attr_has_entity_name = True
         self._attr_device_info = device_info
-        self._panel = panel
+        self._panel = data.panel
+        self._data = data
         self._id = id
         self._output = output
 
     @property
-    def unique_id(self): return f'{self._panel.serial_number}_output_{self._id}'
+    def unique_id(self): return f'{self._data.unique_id}_output_{self._id}'
 
     @property
     def should_poll(self): return False
@@ -53,9 +54,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     panel = data.panel
 
     def setup():
-        device_info = device_info_from_panel(panel)
+        device_info = device_info_from_panel(data)
         async_add_entities(
-            PanelOutputEntity(id, output, device_info, panel)
+            PanelOutputEntity(id, output, device_info, data)
                 for (id, output) in panel.outputs.items())
 
     data.register_entity_setup(setup)

--- a/custom_components/bosch_alarm/switch.py
+++ b/custom_components/bosch_alarm/switch.py
@@ -12,13 +12,13 @@ _LOGGER = logging.getLogger(__name__)
 
 class PanelOutputEntity(SwitchEntity):
     def __init__(self, id, output, panel_conn):
+        self._id = id
+        self._output = output
+        self._panel = panel_conn.panel
         self._observer = output.status_observer
         self._attr_has_entity_name = True
         self._attr_device_info = panel_conn.device_info()
-        self._panel = panel_conn.panel
         self._attr_unique_id = f'{panel_conn.unique_id}_output_{self._id}'
-        self._id = id
-        self._output = output
 
     @property
     def should_poll(self): return False

--- a/custom_components/bosch_alarm/switch.py
+++ b/custom_components/bosch_alarm/switch.py
@@ -49,9 +49,14 @@ class PanelOutputEntity(SwitchEntity):
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up switch entities for outputs"""
 
-    panel = hass.data[DOMAIN][config_entry.entry_id]
-    device_info = device_info_from_panel(panel)
-    async_add_entities(
+    data = hass.data[DOMAIN][config_entry.entry_id]
+    panel = data.panel
+
+    def setup():
+        device_info = device_info_from_panel(panel)
+        async_add_entities(
             PanelOutputEntity(id, output, device_info, panel)
                 for (id, output) in panel.outputs.items())
+
+    data.register_entity_setup(setup)
 

--- a/custom_components/bosch_alarm/switch.py
+++ b/custom_components/bosch_alarm/switch.py
@@ -11,12 +11,12 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 class PanelOutputEntity(SwitchEntity):
-    def __init__(self, id, output, connection):
+    def __init__(self, id, output, panel_conn):
         self._observer = output.status_observer
         self._attr_has_entity_name = True
-        self._attr_device_info = connection.device_info()
-        self._panel = connection.panel
-        self._attr_unique_id = f'{connection.unique_id}_output_{self._id}'
+        self._attr_device_info = panel_conn.device_info()
+        self._panel = panel_conn.panel
+        self._attr_unique_id = f'{panel_conn.unique_id}_output_{self._id}'
         self._id = id
         self._output = output
 
@@ -46,13 +46,13 @@ class PanelOutputEntity(SwitchEntity):
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up switch entities for outputs"""
 
-    connection = hass.data[DOMAIN][config_entry.entry_id]
-    panel = connection.panel
+    panel_conn = hass.data[DOMAIN][config_entry.entry_id]
+    panel = panel_conn.panel
 
     def setup():
         async_add_entities(
-            PanelOutputEntity(id, output, connection)
+            PanelOutputEntity(id, output, panel_conn)
                 for (id, output) in panel.outputs.items())
 
-    connection.register_entity_setup(setup)
+    panel_conn.on_connect.append(setup)
 


### PR DESCRIPTION
Resolves #24 

Store a BoschPanel integration specific object instead of the panel, and move the unique ID logic to that.

Load the serial number and model number directly from the config entry instead of reading it out of the panel, so that most of the devices have proper names at startup, even if we aren't connected to the panel.

Forward entry setups immediately, and then start `panel.connect()` in a background task, so that the config entry sets up without a connection to the panel.

set `self._attr_has_entity_name = True` in all entities, and then removed the manual device name appending we do for 
things like the `connection status`. This does mean that all entities have the device name appended, but this seems to be the behaviour home assistant want now, as the documentation states that we should be setting this to true.

After the first successful panel connection after the config entries are loaded, we then call `async_add_entries` to add entities. We do this by having the `async_setup_entry`s in each platform register a setup method, which calls `async_add_entries` and then we call this after `connection_status_observer` fires.

![image](https://github.com/mag1024/bosch-alarm-homeassistant/assets/1862720/fc033a5b-e239-408f-b898-3375a45fe101)
