### PR TITLE
Add in support for doors

### DIFF
--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -24,7 +24,7 @@ from .device import PanelConnection
 from .const import DOMAIN, CONF_INSTALLER_CODE, CONF_USER_CODE
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.ALARM_CONTROL_PANEL, Platform.SENSOR,
-                             Platform.SWITCH]
+                             Platform.SWITCH, Platform.LOCK]
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/bosch_alarm/lock.py
+++ b/custom_components/bosch_alarm/lock.py
@@ -1,4 +1,4 @@
-"""Support for Bosch Alarm Panel points as binary sensors"""
+"""Support for Bosch Alarm Panel doors as locks"""
 
 from __future__ import annotations
 

--- a/custom_components/bosch_alarm/lock.py
+++ b/custom_components/bosch_alarm/lock.py
@@ -1,0 +1,76 @@
+"""Support for Bosch Alarm Panel points as binary sensors"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from homeassistant.components.lock import (
+    LockEntityFeature,
+    LockEntity,
+)
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PanelLockEntity(LockEntity):
+    def __init__(self, id, panel_conn, door):
+        self._observer = door.status_observer
+        self._panel = panel_conn.panel
+        self._attr_unique_id = f"{panel_conn.unique_id}_door_{id}"
+        self._attr_device_info = panel_conn.device_info()
+        self._attr_has_entity_name = True
+        self._door = door
+        self._door_id = id
+        self._attr_supported_features = LockEntityFeature.OPEN
+
+    @property
+    def name(self):
+        return self._door.name
+
+    @property
+    def is_open(self):
+        return self._door.is_open()
+
+    @property
+    def is_locked(self):
+        return self._door.is_locked()
+
+    @property
+    def available(self):
+        return self._door.is_open() or self._door.is_locked()
+
+    @property
+    def should_poll(self):
+        return False
+
+    async def async_lock(self):
+        await self._panel.relock_door(self._door_id)
+
+    async def async_unlock(self):
+        await self._panel.unlock_door(self._door_id)
+
+    async def async_open(self):
+        await self._panel.cycle_door(self._door_id)
+
+    async def async_added_to_hass(self):
+        self._observer.attach(self.schedule_update_ha_state)
+
+    async def async_will_remove_from_hass(self):
+        self._observer.detach(self.schedule_update_ha_state)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up binary sensors for alarm points and the connection status."""
+
+    panel_conn = hass.data[DOMAIN][config_entry.entry_id]
+    panel = panel_conn.panel
+
+    def setup():
+        async_add_entities(
+            PanelLockEntity(id, panel_conn, door) for (id, door) in panel.doors.items()
+        )
+
+    panel_conn.on_connect.append(setup)

--- a/custom_components/bosch_alarm/lock.py
+++ b/custom_components/bosch_alarm/lock.py
@@ -47,13 +47,13 @@ class PanelLockEntity(LockEntity):
         return False
 
     async def async_lock(self):
-        await self._panel.relock_door(self._door_id)
+        await self._panel.door_relock(self._door_id)
 
     async def async_unlock(self):
-        await self._panel.unlock_door(self._door_id)
+        await self._panel.door_unlock(self._door_id)
 
     async def async_open(self):
-        await self._panel.cycle_door(self._door_id)
+        await self._panel.door_cycle(self._door_id)
 
     async def async_added_to_hass(self):
         self._observer.attach(self.schedule_update_ha_state)

--- a/custom_components/bosch_alarm/lock.py
+++ b/custom_components/bosch_alarm/lock.py
@@ -29,10 +29,6 @@ class PanelLockEntity(LockEntity):
         return self._door.name
 
     @property
-    def is_open(self):
-        return self._door.is_open()
-
-    @property
     def is_locked(self):
         return self._door.is_locked()
 

--- a/custom_components/bosch_alarm/lock.py
+++ b/custom_components/bosch_alarm/lock.py
@@ -6,8 +6,7 @@ import logging
 import re
 
 from homeassistant.components.lock import (
-    LockEntityFeature,
-    LockEntity,
+    LockEntity
 )
 
 from .const import DOMAIN
@@ -24,7 +23,6 @@ class PanelLockEntity(LockEntity):
         self._attr_has_entity_name = True
         self._door = door
         self._door_id = id
-        self._attr_supported_features = LockEntityFeature.OPEN
 
     @property
     def name(self):
@@ -52,9 +50,6 @@ class PanelLockEntity(LockEntity):
     async def async_unlock(self):
         await self._panel.door_unlock(self._door_id)
 
-    async def async_open(self):
-        await self._panel.door_cycle(self._door_id)
-
     async def async_added_to_hass(self):
         self._observer.attach(self.schedule_update_ha_state)
 
@@ -63,7 +58,7 @@ class PanelLockEntity(LockEntity):
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up binary sensors for alarm points and the connection status."""
+    """Set up lock entities for each door"""
 
     panel_conn = hass.data[DOMAIN][config_entry.entry_id]
     panel = panel_conn.panel

--- a/custom_components/bosch_alarm/manifest.json
+++ b/custom_components/bosch_alarm/manifest.json
@@ -11,7 +11,7 @@
   "homekit": {},
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mag1024/bosch-alarm-homeassistant/issues",
-  "requirements": ["bosch-alarm-mode2==0.3.37"],
+  "requirements": ["bosch-alarm-mode2==0.3.38"],
   "ssdp": [],
   "version": "1.0.4",
   "zeroconf": []


### PR DESCRIPTION
The solution 4000 adds support for door modules. This PR implements these doors as locks, as this means we have the ability to lock, unlock and cycle the door from home assistant.

Requires https://github.com/mag1024/bosch-alarm-mode2/pull/37 be both merged and released first, as that PR implements doors in bosch-alarm-mode2.

![image](https://github.com/user-attachments/assets/b11cb0d2-48af-4077-860a-061cdc36db6b)

![image](https://github.com/user-attachments/assets/f07d11d3-d6d0-4c92-be74-7bbe5997b535)
