### PR TITLE
Fix setting config_entry explicitly

### DIFF
--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -159,11 +159,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a options flow for Bosch Alarm."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:


### PR DESCRIPTION
closes #64 

Looks like config_entry is now provided by `OptionsFlow` and it no longer needs to be set up by `__init__` .

This will break in home assistant 2025.12, so we probably should fix this now so we don't have any issues later

```2025-01-26 12:58:46.502 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'bosch_alarm' sets option flow config_entry explicitly, which is deprecated at custom_components/bosch_alarm/config_flow.py, line 165: self.config_entry = config_entry. This will stop working in Home Assistant 2025.12, please create a bug report at https://github.com/mag1024/bosch-alarm-homeassistant/issues```