### PR TITLE
Add changes necessary to reach bronze quality scale

### DIFF
--- a/custom_components/bosch_alarm/__init__.py
+++ b/custom_components/bosch_alarm/__init__.py
@@ -65,7 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         asyncio.exceptions.TimeoutError,
     ) as err:
         await panel.disconnect()
-        raise ConfigEntryNotReady("Device is offline") from err
+        raise ConfigEntryNotReady("Connection failed") from err
 
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/bosch_alarm/binary_sensor.py
+++ b/custom_components/bosch_alarm/binary_sensor.py
@@ -11,9 +11,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
-from .const import DOMAIN
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -115,11 +113,11 @@ class ConnectionStatusSensor(PanelBinarySensor):
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up binary sensors for alarm points and the connection status."""
 
-    panel_conn = hass.data[DOMAIN][config_entry.entry_id]
+    panel_conn = config_entry.runtime_data
     panel = panel_conn.panel
 
     async_add_entities(
@@ -130,14 +128,11 @@ async def async_setup_entry(
         ]
     )
 
-    def setup():
-        async_add_entities(
-            PointSensor(
-                point,
-                f"{panel_conn.unique_id}_point_{point_id}",
-                panel_conn.device_info(),
-            )
-            for (point_id, point) in panel.points.items()
+    async_add_entities(
+        PointSensor(
+            point,
+            f"{panel_conn.unique_id}_point_{point_id}",
+            panel_conn.device_info(),
         )
-
-    panel_conn.on_connect.append(setup)
+        for (point_id, point) in panel.points.items()
+    )

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PORT,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 
 from .const import CONF_INSTALLER_CODE, CONF_USER_CODE, DOMAIN
@@ -96,13 +96,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 4
     entry: config_entries.ConfigEntry | None = None
-    data: dict[str, Any] | None = None
+    data: dict[str, Any] = {}
 
     @staticmethod
-    @config_entries.callback
+    @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Provide a handler for the options flow."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -112,6 +112,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="user", data_schema=STEP_USER_DATA_SCHEMA
             )
+        self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
         try:
             # Use load_selector = 0 to fetch the panel model without authentication.
             (model, _) = await try_connect(self.hass, user_input, 0)
@@ -159,6 +160,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a options flow for Bosch Alarm."""
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/custom_components/bosch_alarm/config_flow.py
+++ b/custom_components/bosch_alarm/config_flow.py
@@ -159,11 +159,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a options flow for Bosch Alarm."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/custom_components/bosch_alarm/device.py
+++ b/custom_components/bosch_alarm/device.py
@@ -1,4 +1,8 @@
-from homeassistant.helpers.entity import DeviceInfo
+"""Support for connections to a Bosch Alarm Panel."""
+
+from collections.abc import Callable
+
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN
 
@@ -11,7 +15,7 @@ class PanelConnection:
         self.panel = panel
         self.unique_id = unique_id
         self.model = model
-        self.on_connect = []
+        self.on_connect: list[Callable] = []
         panel.connection_status_observer.attach(self._on_connection_status_change)
 
     def _on_connection_status_change(self):

--- a/custom_components/bosch_alarm/icons.json
+++ b/custom_components/bosch_alarm/icons.json
@@ -1,0 +1,8 @@
+{
+    "services": {
+      "set_date_time": {
+        "service": "mdi:clock-edit-outline"
+      }
+    }
+  }
+  

--- a/custom_components/bosch_alarm/lock.py
+++ b/custom_components/bosch_alarm/lock.py
@@ -8,9 +8,7 @@ from typing import Any
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
-from .const import DOMAIN
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,17 +62,14 @@ class PanelLockEntity(LockEntity):
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up lock entities for each door."""
 
-    panel_conn = hass.data[DOMAIN][config_entry.entry_id]
+    panel_conn = config_entry.runtime_data
     panel = panel_conn.panel
 
-    def setup():
-        async_add_entities(
-            PanelLockEntity(lock_id, panel_conn, door)
-            for (lock_id, door) in panel.doors.items()
-        )
-
-    panel_conn.on_connect.append(setup)
+    async_add_entities(
+        PanelLockEntity(lock_id, panel_conn, door)
+        for (lock_id, door) in panel.doors.items()
+    )

--- a/custom_components/bosch_alarm/sensor.py
+++ b/custom_components/bosch_alarm/sensor.py
@@ -1,4 +1,4 @@
-"""Support for Bosch Alarm Panel History as a sensor"""
+"""Support for Bosch Alarm Panel History as a sensor."""
 
 from __future__ import annotations
 
@@ -10,9 +10,9 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, HISTORY_ATTR
+from .const import HISTORY_ATTR
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ class PanelHistorySensor(PanelSensor):
         return "mdi:history"
 
     @property
-    def state(self) -> str:
+    def native_value(self) -> str:
         """The state for this history entity."""
         events = self._panel.events
         if events:
@@ -85,7 +85,7 @@ class PanelFaultsSensor(PanelSensor):
         return "mdi:alert-circle"
 
     @property
-    def state(self) -> str:
+    def native_value(self) -> str:
         """The state of this faults entity."""
         faults = self._panel.panel_faults
         return "\n".join(faults) if faults else "No faults"
@@ -99,9 +99,9 @@ class PanelFaultsSensor(PanelSensor):
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up a sensor for tracking panel history."""
 
-    panel_conn = hass.data[DOMAIN][config_entry.entry_id]
+    panel_conn = config_entry.runtime_data
     async_add_entities([PanelHistorySensor(panel_conn), PanelFaultsSensor(panel_conn)])

--- a/custom_components/bosch_alarm/services.yaml
+++ b/custom_components/bosch_alarm/services.yaml
@@ -5,8 +5,6 @@ set_date_time:
       domain: alarm_control_panel
   fields:
     datetime:
-      name: Date & Time to set
-      description: The date/time to set. The time zone of the Home Assistant instance is assumed. Defaults to current date/time if unset.
       required: false
       example: "2022/11/01 22:15"
       selector:

--- a/custom_components/bosch_alarm/strings.json
+++ b/custom_components/bosch_alarm/strings.json
@@ -4,8 +4,23 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "host": "The hostname or IP address of your Bosch Alarm Panel",
+          "port": "The port used to connect to your Bosch Alarm Panel. This is usually 7700"
+        }
+      },
+      "auth": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "installer_code": "Installer Code",
+          "user_code": "User Code"
+        },
+        "data_description": {
+          "password": "The Mode 2 automation code from your panel",
+          "installer_code": "The Installer Code from your panel",
+          "user_code": "The User Code from your panel"
         }
       }
     },
@@ -16,6 +31,30 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "code": "Arming Code"
+        },
+        "data_description": {
+          "code": "Code used when arming the panel from within Home Assistant. Leave this empty if you don't want to require a code for this."
+        }
+      }
+    }
+  },
+  "services": {
+    "set_date_time": {
+      "name": "Set the Date & Time on the panel",
+      "description": "Set the Date & Time on the panel",
+      "fields": {
+        "datetime": {
+          "name": "Date & Time to set",
+          "description": "The date/time to set. The time zone of the Home Assistant instance is assumed. Defaults to current date/time if unset."
+        }
+      }
     }
   }
 }

--- a/custom_components/bosch_alarm/switch.py
+++ b/custom_components/bosch_alarm/switch.py
@@ -8,9 +8,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
-from .const import DOMAIN
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,17 +57,14 @@ class PanelOutputEntity(SwitchEntity):
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up switch entities for outputs."""
 
-    panel_conn = hass.data[DOMAIN][config_entry.entry_id]
+    panel_conn = config_entry.runtime_data
     panel = panel_conn.panel
 
-    def setup():
-        async_add_entities(
-            PanelOutputEntity(output_id, output, panel_conn)
-            for (output_id, output) in panel.outputs.items()
-        )
-
-    panel_conn.on_connect.append(setup)
+    async_add_entities(
+        PanelOutputEntity(output_id, output, panel_conn)
+        for (output_id, output) in panel.outputs.items()
+    )

--- a/tests/custom_components/bosch_alarm/test_config_flow.py
+++ b/tests/custom_components/bosch_alarm/test_config_flow.py
@@ -102,6 +102,28 @@ async def test_form_exceptions(
         assert result["errors"] == {"base": message}
 
 
+async def test_entry_already_configured(hass: HomeAssistant) -> None:
+    """Test if configuring an entity twice results in an error."""
+
+    entry = MockConfigEntry(
+        domain="bosch_alarm", unique_id="unique_id", data={"host": "0.0.0.0"}
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch("bosch_alarm_mode2.panel.Panel.connect"):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "0.0.0.0"},
+        )
+
+        assert result2["type"] is FlowResultType.ABORT
+        assert result2["reason"] == "already_configured"
+
+
 async def test_options_flow(hass: HomeAssistant) -> None:
     """Test the options flow for bosch_alarm."""
     config_entry = MockConfigEntry(


### PR DESCRIPTION
- Applied formatting changes from home assistant core
- Fixed up a bunch of missing translation strings
- Fixed a bunch of pylint errors
- Throw proper exceptions if we can't connect to a panel or there is an auth failure [test-before-setup](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/test-before-setup)
  - This one did mean changing it so that a failure  to connect would just abort the integration setup and let home assistant handle the retry, instead of finishing the setup and retrying within the integration itself 
- Don't allow the same device to be set up twice [unique-config-entry](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/unique-config-entry)
- Use ConfigEntry.runtime_data to store runtime data [runtime-data](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/runtime-data)